### PR TITLE
Add LanceDB RAG pipeline scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# gzprogergmail
+# LanceDB Chatbot Pipeline
+
+This repository contains three Python scripts that set up a LanceDB-powered retrieval augmented generation (RAG) workflow backed by a llama.cpp model.
+
+## Project Structure
+
+- `initializer.py` – downloads required binaries, models, and verifies library availability.
+- `ingest.py` – indexes Markdown documents into a LanceDB database with embeddings.
+- `chatbot.py` – runs an interactive chatbot that answers questions using the indexed knowledge base.
+- `requirements.txt` – lists Python dependencies needed by the scripts.
+
+## Quick Start
+
+1. **Install dependencies**
+   ```bash
+   python -m pip install -r requirements.txt
+   ```
+
+2. **Run the initializer** (downloads LanceDB model assets, llama.cpp, and GPT-OSS 20B model):
+   ```bash
+   python initializer.py
+   ```
+
+3. **Ingest Markdown files**:
+   ```bash
+   python ingest.py
+   ```
+   When prompted, provide the absolute or relative path to the directory containing `.md` files. The script stores embeddings in a `mydata` folder created alongside the provided directory.
+
+4. **Start the chatbot**:
+   ```bash
+   python chatbot.py <path-to-your-markdown-directory>
+   ```
+   Ensure the path matches the one used during ingestion so the chatbot can open the existing LanceDB database.
+
+## Notes
+
+- The scripts print concise progress updates and terminate with helpful error messages when prerequisites are missing.
+- Downloads performed by `initializer.py` may be large. Make sure adequate disk space and bandwidth are available.
+- The ingestion script chunks documents to approximately 500 tokens with 50-token overlap and stores metadata such as source file paths and line ranges to aid in traceability.

--- a/chatbot.py
+++ b/chatbot.py
@@ -1,0 +1,151 @@
+"""Interactive chatbot that uses LanceDB for retrieval augmented generation with llama.cpp."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import List
+
+from lancedb import connect
+from lancedb.embeddings import get_default_embedding_function
+from llama_cpp import Llama
+
+MODEL_PATH = Path("downloads/models/gpt-oss-20b.Q4_K_M.gguf")
+DATABASE_SUBDIR = "mydata"
+TABLE_NAME = "documents"
+
+
+def printStatus(message: str) -> None:
+    print(f"[chatbot] {message}")
+
+
+def loadModel() -> Llama:
+    if not MODEL_PATH.exists():
+        raise FileNotFoundError(
+            "Model file not found. Please run initializer.py and ensure the download completed."
+        )
+    printStatus("Loading language model (this may take a moment)")
+    model = Llama(model_path=str(MODEL_PATH), n_ctx=4096, n_threads=4)
+    return model
+
+
+def connectDatabase(contentDirectory: Path):
+    databasePath = contentDirectory / DATABASE_SUBDIR
+    if not databasePath.exists():
+        raise FileNotFoundError(
+            f"LanceDB database not found at {databasePath}. Run ingest.py for the target directory first."
+        )
+    db = connect(str(databasePath))
+    return db.open_table(TABLE_NAME)
+
+
+def runHybridSearch(table, queryText: str, embeddingFunction, topK: int = 5) -> List[dict]:
+    vector = embeddingFunction.embed([queryText])[0]
+
+    vectorResults: List[dict] = []
+    keywordResults: List[dict] = []
+
+    try:
+        vectorResults = table.search(vector).metric("cosine").limit(topK).to_list()
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    try:
+        keywordResults = table.search(queryText).limit(topK).to_list()
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    combined: dict[tuple[str, int, int], dict] = {}
+    scoreBias = 1.0
+
+    for rank, item in enumerate(vectorResults, start=1):
+        score = 1 / rank
+        key = (item.get("sourcePath"), item.get("startLine"), item.get("endLine"))
+        if key in combined:
+            combined[key]["score"] += score * scoreBias
+        else:
+            combined[key] = {
+                "score": score * scoreBias,
+                "item": item,
+            }
+
+    for rank, item in enumerate(keywordResults, start=1):
+        key = (item["sourcePath"], item["startLine"], item["endLine"])
+        score = 1 / rank
+        if key in combined:
+            combined[key]["score"] += score
+        else:
+            combined[key] = {"score": score, "item": item}
+
+    ranked = sorted(combined.values(), key=lambda entry: entry["score"], reverse=True)
+    return [entry["item"] for entry in ranked[:topK]]
+
+
+def buildPrompt(query: str, contexts: List[dict]) -> str:
+    contextBlocks = []
+    for item in contexts:
+        block = (
+            f"Source: {item.get('sourcePath')} (lines {item.get('startLine')} - {item.get('endLine')})\n"
+            f"Content:\n{item.get('text')}"
+        )
+        contextBlocks.append(block)
+
+    contextText = "\n\n".join(contextBlocks)
+    prompt = (
+        "You are a concise assistant. Use the provided context to answer the question. "
+        "If the answer is not contained within the context, say you do not know.\n\n"
+        f"Context:\n{contextText}\n\nQuestion: {query}\nAnswer:"
+    )
+    return prompt
+
+
+def startChatLoop(table, model: Llama) -> None:
+    embeddingFunction = get_default_embedding_function()
+
+    while True:
+        try:
+            userInput = input("Ask a question (or type 'exit'): ").strip()
+        except EOFError:
+            print()
+            break
+
+        if not userInput:
+            continue
+        if userInput.lower() in {"exit", "quit"}:
+            break
+
+        contexts = runHybridSearch(table, userInput, embeddingFunction)
+        if not contexts:
+            printStatus("No relevant context found. Consider ingesting more content.")
+            continue
+
+        prompt = buildPrompt(userInput, contexts)
+        try:
+            response = model(prompt, max_tokens=512, stop=["Question:"])
+        except Exception as error:  # pylint: disable=broad-except
+            printStatus(f"Model inference failed: {error}")
+            continue
+
+        text = response.get("choices", [{}])[0].get("text", "").strip()
+        print(f"\n{text}\n")
+
+    printStatus("Goodbye")
+
+
+def runChatbot() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python chatbot.py <path-to-ingested-directory>")
+        sys.exit(1)
+
+    contentDirectory = Path(sys.argv[1]).expanduser().resolve()
+    try:
+        table = connectDatabase(contentDirectory)
+        model = loadModel()
+    except Exception as error:  # pylint: disable=broad-except
+        printStatus(f"Error: {error}")
+        sys.exit(1)
+
+    startChatLoop(table, model)
+
+
+if __name__ == "__main__":
+    runChatbot()

--- a/ingest.py
+++ b/ingest.py
@@ -1,0 +1,161 @@
+"""Ingest Markdown documents into a LanceDB database with vector embeddings."""
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Sequence
+
+from lancedb import connect
+from lancedb.embeddings import get_default_embedding_function
+
+
+@dataclass
+class TokenSlice:
+    tokenText: str
+    lineNumber: int
+
+
+@dataclass
+class Chunk:
+    text: str
+    startLine: int
+    endLine: int
+
+
+def printStatus(message: str) -> None:
+    print(f"[ingest] {message}")
+
+
+def promptForDirectory() -> Path:
+    directoryInput = input("Enter directory containing Markdown files: ").strip()
+    if not directoryInput:
+        raise ValueError("Directory path cannot be empty")
+    directoryPath = Path(directoryInput).expanduser().resolve()
+    if not directoryPath.exists() or not directoryPath.is_dir():
+        raise FileNotFoundError(f"Directory not found: {directoryPath}")
+    return directoryPath
+
+
+def readMarkdownFiles(directoryPath: Path) -> List[Path]:
+    markdownFiles = sorted(directoryPath.rglob("*.md"))
+    return markdownFiles
+
+
+def buildTokenStream(text: str) -> List[TokenSlice]:
+    import bisect
+    import re
+
+    lineOffsets = [0]
+    for index, character in enumerate(text):
+        if character == "\n":
+            lineOffsets.append(index + 1)
+
+    tokens: List[TokenSlice] = []
+    pattern = re.compile(r"\S+|\n")
+    for match in pattern.finditer(text):
+        tokenText = match.group(0)
+        position = match.start()
+        lineIndex = bisect.bisect_right(lineOffsets, position) - 1
+        lineNumber = lineIndex + 1
+        tokens.append(TokenSlice(tokenText=tokenText, lineNumber=lineNumber))
+    return tokens
+
+
+def chunkTokens(tokens: Sequence[TokenSlice], chunkSize: int = 500, overlap: int = 50) -> List[Chunk]:
+    chunks: List[Chunk] = []
+    startIndex = 0
+    totalTokens = len(tokens)
+
+    while startIndex < totalTokens:
+        endIndex = min(startIndex + chunkSize, totalTokens)
+        chunkTokens = tokens[startIndex:endIndex]
+        chunkText = "".join(token.tokenText if token.tokenText == "\n" else f"{token.tokenText} " for token in chunkTokens)
+        chunkText = chunkText.strip()
+
+        if not chunkText:
+            startIndex += chunkSize - overlap
+            continue
+
+        startLine = chunkTokens[0].lineNumber
+        endLine = chunkTokens[-1].lineNumber
+        chunks.append(Chunk(text=chunkText, startLine=startLine, endLine=endLine))
+
+        if endIndex == totalTokens:
+            break
+        startIndex = max(endIndex - overlap, startIndex + 1)
+
+    return chunks
+
+
+def generateRecords(filePath: Path, embeddingFunction) -> List[dict]:
+    content = filePath.read_text(encoding="utf-8")
+    tokens = buildTokenStream(content)
+    chunks = chunkTokens(tokens)
+
+    records: List[dict] = []
+    for chunk in chunks:
+        vector = embeddingFunction.embed([chunk.text])[0]
+        records.append(
+            {
+                "text": chunk.text,
+                "vector": vector,
+                "sourcePath": str(filePath),
+                "startLine": chunk.startLine,
+                "endLine": chunk.endLine,
+            }
+        )
+    return records
+
+
+def upsertRecords(table, records: Sequence[dict]) -> None:
+    if not records:
+        return
+    table.add(records)
+
+
+def ingestDirectory(directoryPath: Path) -> None:
+    markdownFiles = readMarkdownFiles(directoryPath)
+    if not markdownFiles:
+        raise RuntimeError("No Markdown files were found in the provided directory")
+
+    databasePath = directoryPath / "mydata"
+    db = connect(str(databasePath))
+    tableName = "documents"
+    table = db.open_table(tableName) if tableName in db.table_names() else None
+    if table is not None:
+        try:
+            table.create_index(metric="cosine", vector_column_name="vector")
+        except Exception:  # pylint: disable=broad-except
+            pass
+    embeddingFunction = get_default_embedding_function()
+
+    for filePath in markdownFiles:
+        printStatus(f"Processing {filePath}")
+        records = generateRecords(filePath, embeddingFunction)
+        if not records:
+            printStatus(f"Skipping empty content in {filePath}")
+            continue
+        if table is None:
+            table = db.create_table(tableName, data=records)
+            try:
+                table.create_index(metric="cosine", vector_column_name="vector")
+            except Exception:  # pylint: disable=broad-except
+                pass
+        else:
+            upsertRecords(table, records)
+
+    printStatus("Ingestion complete")
+
+
+def runIngestWorkflow() -> None:
+    try:
+        directoryPath = promptForDirectory()
+        ingestDirectory(directoryPath)
+    except Exception as error:  # pylint: disable=broad-except
+        printStatus(f"Error: {error}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    runIngestWorkflow()

--- a/initializer.py
+++ b/initializer.py
@@ -1,0 +1,181 @@
+"""Utility script to prepare dependencies required for the LanceDB + llama.cpp pipeline."""
+from __future__ import annotations
+
+import hashlib
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.error import URLError
+from urllib.request import urlopen, urlretrieve
+
+LANCE_DB_PACKAGE = "lancedb"
+LLAMA_CPP_PACKAGE = "llama-cpp-python"
+
+LLAMA_CPP_URLS = {
+    "Linux": "https://github.com/ggerganov/llama.cpp/releases/download/b3539/llama-b3539-bin-linux-x86_64.zip",
+    "Darwin": "https://github.com/ggerganov/llama.cpp/releases/download/b3539/llama-b3539-bin-macos-universal2.zip",
+    "Windows": "https://github.com/ggerganov/llama.cpp/releases/download/b3539/llama-b3539-bin-win-x64.zip",
+}
+
+GPT_OSS_MODEL_URL = "https://huggingface.co/TheBloke/gpt-oss-20B-GGUF/resolve/main/gpt-oss-20b.Q4_K_M.gguf"
+
+DOWNLOAD_DIRECTORY = Path("downloads")
+
+
+class InitializationError(Exception):
+    """Raised when the initializer fails to complete a mandatory step."""
+
+
+def printStatus(message: str) -> None:
+    """Print a concise status message."""
+
+    print(f"[setup] {message}")
+
+
+def runCommand(command: list[str]) -> None:
+    """Run a subprocess command and raise an informative error on failure."""
+
+    try:
+        subprocess.run([sys.executable, "-m", *command], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as error:
+        raise InitializationError(
+            f"Command failed: {' '.join(error.cmd)}\nstdout: {error.stdout.decode()}\nstderr: {error.stderr.decode()}"
+        ) from error
+
+
+def ensurePackageInstalled(packageName: str) -> None:
+    """Install a package with pip if it is unavailable."""
+
+    try:
+        __import__(packageName.replace("-", "_"))
+        printStatus(f"Package '{packageName}' already available")
+        return
+    except ModuleNotFoundError:
+        printStatus(f"Installing package '{packageName}'")
+
+    runCommand(["pip", "install", packageName])
+    __import__(packageName.replace("-", "_"))
+    printStatus(f"Package '{packageName}' installed")
+
+
+def ensureLanceDb() -> None:
+    """Ensure LanceDB is installed and that the default embedding model is cached."""
+
+    ensurePackageInstalled(LANCE_DB_PACKAGE)
+
+    from lancedb.embeddings import get_default_embedding_function
+
+    printStatus("Preparing LanceDB default embedding model")
+    embeddingFunction = get_default_embedding_function()
+
+    # Trigger a download (if needed) by embedding a trivial text sample.
+    try:
+        _ = embeddingFunction.embed(["Initialization probe"])
+        printStatus("Default embedding model ready")
+    except Exception as error:  # pylint: disable=broad-except
+        raise InitializationError(f"Failed to initialize LanceDB embedding model: {error}") from error
+
+
+def downloadFile(url: str, destination: Path, expectedSha256: Optional[str] = None) -> None:
+    """Download a file if missing and verify its integrity if a checksum is provided."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.exists():
+        printStatus(f"File already downloaded: {destination.name}")
+        if expectedSha256:
+            verifyChecksum(destination, expectedSha256)
+        return
+
+    printStatus(f"Downloading {destination.name}")
+    try:
+        with urlopen(url) as response:  # nosec B310
+            totalSize = int(response.headers.get("Content-Length", "0"))
+        if totalSize and totalSize > 0:
+            printStatus(f"Download size: {totalSize / (1024 * 1024):.2f} MB")
+    except URLError:
+        printStatus("Could not fetch file size; continuing with download")
+
+    try:
+        urlretrieve(url, destination)  # nosec B310
+    except URLError as error:
+        raise InitializationError(f"Failed to download from {url}: {error}") from error
+
+    if expectedSha256:
+        verifyChecksum(destination, expectedSha256)
+    printStatus(f"Saved to {destination}")
+
+
+def verifyChecksum(filePath: Path, expectedSha256: str) -> None:
+    """Validate a file against a sha256 checksum."""
+
+    hashObject = hashlib.sha256()
+    with filePath.open("rb") as filePointer:
+        for chunk in iter(lambda: filePointer.read(8192), b""):
+            hashObject.update(chunk)
+    checksum = hashObject.hexdigest()
+    if checksum != expectedSha256:
+        filePath.unlink(missing_ok=True)
+        raise InitializationError(
+            f"Checksum mismatch for {filePath.name}: expected {expectedSha256}, received {checksum}"
+        )
+    printStatus(f"Checksum verified for {filePath.name}")
+
+
+def ensureLlamaCppBinary() -> None:
+    """Download the llama.cpp prebuilt binary appropriate for the current platform."""
+
+    systemName = platform.system()
+    url = LLAMA_CPP_URLS.get(systemName)
+    if not url:
+        raise InitializationError(f"Unsupported platform for llama.cpp binary download: {systemName}")
+
+    archiveName = Path(url).name
+    archivePath = DOWNLOAD_DIRECTORY / archiveName
+
+    downloadFile(url, archivePath)
+
+    extractTarget = DOWNLOAD_DIRECTORY / "llama.cpp"
+    if extractTarget.exists():
+        printStatus("llama.cpp binary already extracted")
+        return
+
+    printStatus("Extracting llama.cpp binary archive")
+    shutil.unpack_archive(str(archivePath), str(extractTarget))
+    printStatus("llama.cpp binary ready")
+
+
+def ensureLlamaCppPython() -> None:
+    """Install llama-cpp-python module."""
+
+    ensurePackageInstalled(LLAMA_CPP_PACKAGE)
+
+
+def ensureGptOssModel() -> None:
+    """Download the GPT-OSS 20B quantized model file."""
+
+    modelFileName = Path(GPT_OSS_MODEL_URL).name
+    modelPath = DOWNLOAD_DIRECTORY / "models" / modelFileName
+    downloadFile(GPT_OSS_MODEL_URL, modelPath)
+
+
+def runInitializer() -> None:
+    """Run the entire initialization workflow."""
+
+    try:
+        ensureLanceDb()
+        ensureLlamaCppBinary()
+        ensureLlamaCppPython()
+        ensureGptOssModel()
+    except InitializationError as error:
+        printStatus(str(error))
+        sys.exit(1)
+
+    printStatus("Initialization complete")
+
+
+if __name__ == "__main__":
+    runInitializer()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+lancedb>=0.5.0
+llama-cpp-python>=0.2.0


### PR DESCRIPTION
## Summary
- add initializer to prepare LanceDB, llama.cpp assets, and GPT-OSS model downloads
- build ingestion workflow that chunks Markdown files, embeds them, and stores metadata in LanceDB
- create chatbot script that performs hybrid LanceDB search and queries the llama.cpp model
- document usage steps and declare dependencies for easy setup

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc9a65fa088320b27516013a27f3f7